### PR TITLE
Use new test.support helper submodules in tests

### DIFF
--- a/Lib/distutils/tests/test_archive_util.py
+++ b/Lib/distutils/tests/test_archive_util.py
@@ -13,7 +13,9 @@ from distutils.archive_util import (check_archive_formats, make_tarball,
                                     ARCHIVE_FORMATS)
 from distutils.spawn import find_executable, spawn
 from distutils.tests import support
-from test.support import check_warnings, run_unittest, patch, change_cwd
+from test.support import run_unittest, patch
+from test.support.os_helper import change_cwd
+from test.support.warnings_helper import check_warnings
 
 try:
     import grp

--- a/Lib/distutils/tests/test_bdist_msi.py
+++ b/Lib/distutils/tests/test_bdist_msi.py
@@ -1,7 +1,8 @@
 """Tests for distutils.command.bdist_msi."""
 import sys
 import unittest
-from test.support import run_unittest, check_warnings
+from test.support import run_unittest
+from test.support.warnings_helper import check_warnings
 from distutils.tests import support
 
 

--- a/Lib/distutils/tests/test_bdist_wininst.py
+++ b/Lib/distutils/tests/test_bdist_wininst.py
@@ -2,7 +2,8 @@
 import sys
 import platform
 import unittest
-from test.support import run_unittest, check_warnings
+from test.support import run_unittest
+from test.support.warnings_helper import check_warnings
 
 from distutils.command.bdist_wininst import bdist_wininst
 from distutils.tests import support

--- a/Lib/distutils/tests/test_core.py
+++ b/Lib/distutils/tests/test_core.py
@@ -5,8 +5,8 @@ import distutils.core
 import os
 import shutil
 import sys
-import test.support
 from test.support import captured_stdout, run_unittest
+from test.support import os_helper
 import unittest
 from distutils.tests import support
 from distutils import log
@@ -62,13 +62,13 @@ class CoreTestCase(support.EnvironGuard, unittest.TestCase):
         super(CoreTestCase, self).tearDown()
 
     def cleanup_testfn(self):
-        path = test.support.TESTFN
+        path = os_helper.TESTFN
         if os.path.isfile(path):
             os.remove(path)
         elif os.path.isdir(path):
             shutil.rmtree(path)
 
-    def write_setup(self, text, path=test.support.TESTFN):
+    def write_setup(self, text, path=os_helper.TESTFN):
         f = open(path, "w")
         try:
             f.write(text)
@@ -105,8 +105,8 @@ class CoreTestCase(support.EnvironGuard, unittest.TestCase):
         cwd = os.getcwd()
 
         # Create a directory and write the setup.py file there:
-        os.mkdir(test.support.TESTFN)
-        setup_py = os.path.join(test.support.TESTFN, "setup.py")
+        os.mkdir(os_helper.TESTFN)
+        setup_py = os.path.join(os_helper.TESTFN, "setup.py")
         distutils.core.run_setup(
             self.write_setup(setup_prints_cwd, path=setup_py))
 

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -12,8 +12,9 @@ from distutils.dist import Distribution, fix_help_options
 from distutils.cmd import Command
 
 from test.support import (
-     TESTFN, captured_stdout, captured_stderr, run_unittest
+     captured_stdout, captured_stderr, run_unittest
 )
+from test.support.os_helper import TESTFN
 from distutils.tests import support
 from distutils import log
 

--- a/Lib/distutils/tests/test_extension.py
+++ b/Lib/distutils/tests/test_extension.py
@@ -3,7 +3,8 @@ import unittest
 import os
 import warnings
 
-from test.support import check_warnings, run_unittest
+from test.support import run_unittest
+from test.support.warnings_helper import check_warnings
 from distutils.extension import read_setup_file, Extension
 
 class ExtensionTestCase(unittest.TestCase):

--- a/Lib/distutils/tests/test_file_util.py
+++ b/Lib/distutils/tests/test_file_util.py
@@ -8,7 +8,9 @@ from distutils.file_util import move_file, copy_file
 from distutils import log
 from distutils.tests import support
 from distutils.errors import DistutilsFileError
-from test.support import run_unittest, unlink
+from test.support import run_unittest
+from test.support.os_helper import unlink
+
 
 class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
 

--- a/Lib/distutils/tests/test_filelist.py
+++ b/Lib/distutils/tests/test_filelist.py
@@ -9,6 +9,7 @@ from distutils.filelist import glob_to_re, translate_pattern, FileList
 from distutils import filelist
 
 import test.support
+from test.support import os_helper
 from test.support import captured_stdout, run_unittest
 from distutils.tests import support
 
@@ -295,7 +296,7 @@ class FileListTestCase(support.LoggingSilencer,
 
 
 class FindAllTestCase(unittest.TestCase):
-    @test.support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_missing_symlink(self):
         with test.support.temp_cwd():
             os.symlink('foo', 'bar')

--- a/Lib/distutils/tests/test_register.py
+++ b/Lib/distutils/tests/test_register.py
@@ -5,7 +5,8 @@ import getpass
 import urllib
 import warnings
 
-from test.support import check_warnings, run_unittest
+from test.support import run_unittest
+from test.support.warnings_helper import check_warnings
 
 from distutils.command import register as register_module
 from distutils.command.register import register

--- a/Lib/distutils/tests/test_sdist.py
+++ b/Lib/distutils/tests/test_sdist.py
@@ -6,7 +6,8 @@ import warnings
 import zipfile
 from os.path import join
 from textwrap import dedent
-from test.support import captured_stdout, check_warnings, run_unittest
+from test.support import captured_stdout, run_unittest
+from test.support.warnings_helper import check_warnings
 
 try:
     import zlib

--- a/Lib/distutils/tests/test_sysconfig.py
+++ b/Lib/distutils/tests/test_sysconfig.py
@@ -10,7 +10,10 @@ import unittest
 from distutils import sysconfig
 from distutils.ccompiler import get_default_compiler
 from distutils.tests import support
-from test.support import TESTFN, run_unittest, check_warnings, swap_item
+from test.support import run_unittest, swap_item
+from test.support.os_helper import TESTFN
+from test.support.warnings_helper import check_warnings
+
 
 class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
     def setUp(self):

--- a/Lib/distutils/tests/test_unixccompiler.py
+++ b/Lib/distutils/tests/test_unixccompiler.py
@@ -1,7 +1,8 @@
 """Tests for distutils.unixccompiler."""
 import sys
 import unittest
-from test.support import EnvironmentVarGuard, run_unittest
+from test.support import run_unittest
+from test.support.os_helper import EnvironmentVarGuard
 
 from distutils import sysconfig
 from distutils.unixccompiler import UnixCCompiler

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -16,6 +16,7 @@
 import contextlib
 import unittest
 from test import support
+from test.support import os_helper 
 from itertools import permutations, product
 from random import randrange, sample, choice
 import warnings
@@ -39,7 +40,7 @@ except ImportError:
     ctypes = None
 
 try:
-    with support.EnvironmentVarGuard() as os.environ, \
+    with os_helper.EnvironmentVarGuard() as os.environ, \
          warnings.catch_warnings():
         from numpy import ndarray as numpy_array
 except ImportError:

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -7,7 +7,9 @@ import _ast
 import tempfile
 import types
 from test import support
-from test.support import script_helper, FakePath
+from test.support import script_helper
+from test.support.os_helper import FakePath
+
 
 class TestSpecifics(unittest.TestCase):
 

--- a/Lib/test/test_filecmp.py
+++ b/Lib/test/test_filecmp.py
@@ -5,13 +5,14 @@ import tempfile
 import unittest
 
 from test import support
+from test.support import os_helper
 
 
 class FileCompareTestCase(unittest.TestCase):
     def setUp(self):
-        self.name = support.TESTFN
-        self.name_same = support.TESTFN + '-same'
-        self.name_diff = support.TESTFN + '-diff'
+        self.name = os_helper.TESTFN
+        self.name_same = os_helper.TESTFN + '-same'
+        self.name_diff = os_helper.TESTFN + '-diff'
         data = 'Contents of file go here.\n'
         for name in [self.name, self.name_same, self.name_diff]:
             with open(name, 'w') as output:

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -24,8 +24,10 @@ from io import BytesIO, StringIO
 from fileinput import FileInput, hook_encoded
 from pathlib import Path
 
-from test.support import verbose, TESTFN, check_warnings
-from test.support import unlink as safe_unlink
+from test.support import verbose
+from test.support.os_helper import TESTFN
+from test.support.os_helper import unlink as safe_unlink
+from test.support import warnings_helper
 from test import support
 from unittest import mock
 
@@ -39,7 +41,7 @@ class BaseTests:
     # temp file's name.
     def writeTmp(self, content, *, mode='w'):  # opening in text mode is the default
         fd, name = tempfile.mkstemp()
-        self.addCleanup(support.unlink, name)
+        self.addCleanup(safe_unlink, name)
         with open(fd, mode) as f:
             f.write(content)
         return name
@@ -234,9 +236,9 @@ class FileInputTests(BaseTests, unittest.TestCase):
             pass
         # try opening in universal newline mode
         t1 = self.writeTmp(b"A\nB\r\nC\rD", mode="wb")
-        with check_warnings(('', DeprecationWarning)):
+        with warnings_helper.check_warnings(('', DeprecationWarning)):
             fi = FileInput(files=t1, mode="U")
-        with check_warnings(('', DeprecationWarning)):
+        with warnings_helper.check_warnings(('', DeprecationWarning)):
             lines = list(fi)
         self.assertEqual(lines, ["A\n", "B\n", "C\n", "D"])
 
@@ -353,7 +355,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
         with FileInput(files=[]) as fi:
             self.assertEqual(fi._files, ('-',))
 
-    @support.ignore_warnings(category=DeprecationWarning)
+    @warnings_helper.ignore_warnings(category=DeprecationWarning)
     def test__getitem__(self):
         """Tests invoking FileInput.__getitem__() with the current
            line number"""
@@ -371,7 +373,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
             with FileInput(files=[t]) as fi:
                 self.assertEqual(fi[0], "line1\n")
 
-    @support.ignore_warnings(category=DeprecationWarning)
+    @warnings_helper.ignore_warnings(category=DeprecationWarning)
     def test__getitem__invalid_key(self):
         """Tests invoking FileInput.__getitem__() with an index unequal to
            the line number"""
@@ -381,7 +383,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
                 fi[1]
         self.assertEqual(cm.exception.args, ("accessing lines out of order",))
 
-    @support.ignore_warnings(category=DeprecationWarning)
+    @warnings_helper.ignore_warnings(category=DeprecationWarning)
     def test__getitem__eof(self):
         """Tests invoking FileInput.__getitem__() with the line number but at
            end-of-input"""
@@ -400,7 +402,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
         os_unlink_replacement = UnconditionallyRaise(OSError)
         try:
             t = self.writeTmp("\n")
-            self.addCleanup(support.unlink, t + '.bak')
+            self.addCleanup(safe_unlink, t + '.bak')
             with FileInput(files=[t], inplace=True) as fi:
                 next(fi) # make sure the file is opened
                 os.unlink = os_unlink_replacement

--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -10,7 +10,9 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from test.support import import_module, unlink, temp_dir, TESTFN, verbose
+from test.support import verbose
+from test.support.import_helper import import_module
+from test.support.os_helper import unlink, temp_dir, TESTFN
 from test.support.script_helper import assert_python_ok
 
 # Skip tests if there is no readline module

--- a/Lib/test/test_smtpnet.py
+++ b/Lib/test/test_smtpnet.py
@@ -1,10 +1,11 @@
 import unittest
 from test import support
+from test.support import import_helper
 from test.support import socket_helper
 import smtplib
 import socket
 
-ssl = support.import_module("ssl")
+ssl = import_helper.import_module("ssl")
 
 support.requires("network")
 

--- a/Lib/test/test_structmembers.py
+++ b/Lib/test/test_structmembers.py
@@ -1,8 +1,9 @@
 import unittest
-from test import support
+from test.support import import_helper
+from test.support import warnings_helper
 
 # Skip this test if the _testcapi module isn't available.
-support.import_module('_testcapi')
+import_helper.import_module('_testcapi')
 from _testcapi import _test_structmembersType, \
     CHAR_MAX, CHAR_MIN, UCHAR_MAX, \
     SHRT_MAX, SHRT_MIN, USHRT_MAX, \
@@ -116,27 +117,27 @@ class ReadWriteTests(unittest.TestCase):
 class TestWarnings(unittest.TestCase):
 
     def test_byte_max(self):
-        with support.check_warnings(('', RuntimeWarning)):
+        with warnings_helper.check_warnings(('', RuntimeWarning)):
             ts.T_BYTE = CHAR_MAX+1
 
     def test_byte_min(self):
-        with support.check_warnings(('', RuntimeWarning)):
+        with warnings_helper.check_warnings(('', RuntimeWarning)):
             ts.T_BYTE = CHAR_MIN-1
 
     def test_ubyte_max(self):
-        with support.check_warnings(('', RuntimeWarning)):
+        with warnings_helper.check_warnings(('', RuntimeWarning)):
             ts.T_UBYTE = UCHAR_MAX+1
 
     def test_short_max(self):
-        with support.check_warnings(('', RuntimeWarning)):
+        with warnings_helper.check_warnings(('', RuntimeWarning)):
             ts.T_SHORT = SHRT_MAX+1
 
     def test_short_min(self):
-        with support.check_warnings(('', RuntimeWarning)):
+        with warnings_helper.check_warnings(('', RuntimeWarning)):
             ts.T_SHORT = SHRT_MIN-1
 
     def test_ushort_max(self):
-        with support.check_warnings(('', RuntimeWarning)):
+        with warnings_helper.check_warnings(('', RuntimeWarning)):
             ts.T_USHORT = USHRT_MAX+1
 
 

--- a/Lib/test/test_tools/__init__.py
+++ b/Lib/test/test_tools/__init__.py
@@ -4,6 +4,7 @@ import importlib
 import os.path
 import unittest
 from test import support
+from test.support import import_helper
 
 basepath = os.path.normpath(
         os.path.dirname(                 # <src/install dir>
@@ -26,11 +27,11 @@ def skip_if_missing(tool=None):
 @contextlib.contextmanager
 def imports_under_tool(name, *subdirs):
     tooldir = os.path.join(toolsdir, name, *subdirs)
-    with support.DirsOnSysPath(tooldir) as cm:
+    with import_helper.DirsOnSysPath(tooldir) as cm:
         yield cm
 
 def import_tool(toolname):
-    with support.DirsOnSysPath(scriptsdir):
+    with import_helper.DirsOnSysPath(scriptsdir):
         return importlib.import_module(toolname)
 
 def load_tests(*args):


### PR DESCRIPTION
Use test helpers in the following test cases:
* tests of distutils
* test_buffer
* test_compile
* test_filecmp
* test_fileinput
* test_readline
* test_smtpnet
* test_structmembers
* test_tools

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
