### PR TITLE
bpo-44133: Export Py_FrozenMain() symbol

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -103,6 +103,11 @@ Optimizations
 Build Changes
 =============
 
+* The Python binary now builds the libpython static library using
+  ``-Wl,--whole-archive`` linker option to export all symbols exported by
+  object files. Previously, the ``Py_FrozenMain`` symbol was not exported.
+  (Contributed by Victor Stinner in :issue:`44133`.)
+
 
 Deprecated
 ==========

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -587,7 +587,7 @@ clinic: check-clean-src $(srcdir)/Modules/_blake2/blake2s_impl.c
 
 # Build the interpreter
 $(BUILDPYTHON):	Programs/python.o $(LIBRARY_DEPS)
-	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
+	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o -Wl,--whole-archive $(BLDLIBRARY) -Wl,--no-whole-archive $(LIBS) $(MODLIBS) $(SYSLIBS)
 
 platform: $(BUILDPYTHON) pybuilddir.txt
 	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform

--- a/Misc/NEWS.d/next/Build/2021-05-14-19-02-04.bpo-44133.XnroKM.rst
+++ b/Misc/NEWS.d/next/Build/2021-05-14-19-02-04.bpo-44133.XnroKM.rst
@@ -1,0 +1,4 @@
+The Python binary now builds the libpython static library using
+``-Wl,--whole-archive`` linker option to export all symbols exported by
+object files. Previously, the ``Py_FrozenMain`` symbol was not exported.
+Patch by Victor Stinner.


### PR DESCRIPTION
The Python binary now builds the libpython static library using
"-Wl,--whole-archive" linker option to export all symbols exported by
object files. Previously, the "Py_FrozenMain" symbol was not
exported.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
